### PR TITLE
feat: add post on autonomous agents that sleep

### DIFF
--- a/_posts/2026-06-05-autonomous-agents-that-sleep.markdown
+++ b/_posts/2026-06-05-autonomous-agents-that-sleep.markdown
@@ -1,0 +1,117 @@
+---
+title: "Autonomous agents that sleep"
+date: 2026-06-05T10:00:00+02:00
+excerpt: "The obvious way to build an autonomous agent is a loop that runs until the work is done. It demos beautifully and falls apart the moment the agent has to wait. The fix is to turn the loop inside-out, and what's left looks a lot more like sleep."
+tags:
+  - ai
+  - agents
+  - claude
+  - system design
+published: true
+---
+
+The obvious way to build an autonomous agent is a loop: call the model, let it act, check whether the work is done, and go around again until it is. It looks great in a demo, right up until the first time the agent has to *wait*, whether for a slow CI build, for a human review, or for anything it doesn't control. A loop has nothing useful to do while it waits, and it can't be reached while it spins.
+
+There's a better shape. It looks less like a loop and more like sleep: do one short turn, report what happened, and stop. Something *outside* the agent holds the state, waits, and starts the next turn only when the world actually changes.
+
+![An autonomous agent's lifecycle: it does one turn, reports a status line, goes idle, and is woken by an event from the world, then repeats.](/images/autonomous-agents-that-sleep/lifecycle.svg)
+
+The examples here use Anthropic's [Claude Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview), which exposes a single `query()` call that runs a full agent turn for us. But the idea is the SDK-agnostic part. It's about where the loop lives, not which library runs it.
+
+## The loop that never ends
+
+A loop is the first thing anyone reaches for, and for a one-shot task it's exactly right: keep going until the answer is good enough. The shape only breaks once the task crosses something the agent can't finish on its own, like opening a pull request and needing it to go green.
+
+![The naive loop: call the model, act, check if CI is green, and loop back to wait when it isn't. Three failure modes: it burns budget polling, it can't be steered mid-loop, and a crash loses all progress.](/images/autonomous-agents-that-sleep/naive-loop.svg)
+
+Now the loop has to wait for a build that takes twelve minutes, and three problems show up at once. It **burns budget** sitting in the loop, re-asking the model whether CI is done yet. It **can't be steered**: a new instruction has nowhere to land until the loop comes back around to check. And if the process dies, it suffers total **amnesia**, because the loop's progress lived in memory, so a restart begins from nothing.
+
+The root cause is the same in all three. The durable, long-lived part of the system is *inside* the agent's loop, where it's expensive to run, hard to interrupt, and easy to lose.
+
+## Turn the loop inside-out
+
+So we move it out. The loop becomes a small, ordinary program (call it the **controller**) that lives outside the agent and owns everything durable: which session is in flight, which pull requests are open, what's still pending. The agent is no longer a long-running thing. It's a function the controller calls for one turn at a time.
+
+![The controller, an always-on process, holds the durable state and receives events from the world. For each event it spawns a single stateless agent turn, which does the work, returns a status line, and exits.](/images/autonomous-agents-that-sleep/architecture.svg)
+
+Events from the world arrive at the controller, not the agent: a CI result, a review comment, a new ticket, a person stepping in to redirect. The controller decides what they mean, spawns a turn to handle them, records the outcome, and goes quiet again. A turn is genuinely short-lived. It spins up, does its work, and exits, leaving nothing running behind it.
+
+In the Claude Agent SDK, that turn is one `query()` call we drain to the end:
+
+{% highlight javascript %}
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+// One turn: hand the agent a prompt, let it work, collect what it did. Then it's over.
+async function runTurn(prompt, options) {
+  let sessionId, reply;
+  for await (const msg of query({ prompt, options })) {
+    if (msg.type === 'system' && msg.subtype === 'init') sessionId = msg.session_id;
+    if (msg.type === 'result') reply = msg.result;
+  }
+  return { sessionId, reply };
+}
+{% endhighlight %}
+
+## A turn never waits
+
+This is the one rule that makes the whole thing hold together: **a turn does its work and ends. It never waits.** After the agent pushes a branch or opens a pull request, it stops. It does not poll CI. It does not sleep for twelve minutes. It does not block on a review.
+
+In practice the rule lives in the agent's own instructions, in plain words:
+
+> After pushing or opening a pull request, end the turn. Never wait, sleep, or poll for CI. Results and review comments arrive as new events that wake the next turn.
+
+A good teammate works the same way. They don't stand around watching a progress bar fill; they push the change, say "I'll pick it back up when CI's done," and move on to something else. A notification brings them back. The agent's notification is an event landing at the controller, which starts a fresh turn. The build it was "waiting" for cost nothing, because nobody was waiting.
+
+## How a turn says what happened
+
+If a turn just ends, the controller needs to know what it accomplished and what to watch next. Reading the agent's prose reply and guessing is fragile. So every turn ends with one machine-readable line: a small, fixed contract the controller can parse without interpreting English.
+
+![The turn's reply has two readers: a human reads the prose at the top, while the controller reads only the final AGENT_STATUS line. From that line it learns which PRs to watch, what note to surface, and whether a human is needed.](/images/autonomous-agents-that-sleep/status-contract.svg)
+
+The prose at the top is for the teammate reading along. The last line is for the code:
+
+{% highlight javascript %}
+// Every turn ends with one line the controller can read:
+//   AGENT_STATUS: {"prs":[{"repo":"backend","url":".../pull/42"}],"note":"opened a draft PR"}
+
+const status = parseLastStatusLine(reply);     // ignore the prose, read the contract
+for (const pr of status.prs) watch(pr);        // now monitor those PRs for CI + reviews
+if (status.attention) pingHuman(status.attention);   // only when genuinely blocked
+{% endhighlight %}
+
+That single line is enough to drive the controller's state machine: which pull requests to monitor, a short note to pass along, and an optional `attention` field the agent sets *only* when it's stuck and needs a person. There's no prose-scraping and no guessing. The agent talks to people in sentences and to the controller in one predictable shape.
+
+## The session remembers, even though the turn forgot
+
+A turn that ends and leaves nothing running sounds like it would also forget everything, starting each time as a stranger to its own work. It doesn't, because the conversation is saved separately from the process that ran it. The SDK assigns each turn's first message a **session id**. Hold onto it, and a later turn can *resume* the same conversation with its full history intact.
+
+{% highlight javascript %}
+// A later event (CI failed, a new comment) starts a fresh turn,
+// but resumes the same session, so the agent still has all its context.
+runTurn(continuePrompt, { ...options, resume: sessionId });
+{% endhighlight %}
+
+So the turn is stateless, but the agent is not amnesiac. When CI comes back red an hour later, the controller wakes the same session: the agent already knows what it changed and why, and just needs the new fact, the failing test, to keep going. Short-lived turns, long-lived memory.
+
+## Why this works
+
+Pulling the loop out of the agent fixes all three problems from the top, and the reasons are worth stating plainly:
+
+- **It's cheap.** Waiting is free, because nothing is running while the agent is idle. We pay for the model only during the seconds it's actually doing work.
+- **It's steerable.** A person can drop a message in at any time. It's just another event in the controller's queue, handled on the next turn, with no loop to interrupt.
+- **It survives crashes.** The durable state lives in the controller's store, not in a running process. Restart the controller and every in-flight thread is still there, ready to resume its session.
+- **It's observable.** Every turn ends with a status line and a human-readable note, so there's always a clear record of what the agent did and why it stopped.
+
+## But wait, why not just let the agent sleep inside the loop?
+
+A fair objection: the agent could stay in its loop and simply `sleep` between CI checks, so the model isn't called while it waits. That removes the token cost, but not the real problem. A sleeping loop is still a running process holding all of its state in memory, so a crash still means amnesia, and a person still can't reach it until it wakes on its own schedule rather than when something actually happens. "Sleep inside the loop" keeps the fragile part; "end the turn and let an event wake it" removes it. The difference isn't the nap. It's *who* owns the waiting.
+
+## Wrap-up
+
+An autonomous agent doesn't have to be a process that runs until it's done. It can be a series of short turns, each one picking up a saved conversation, doing a piece of work, reporting a single status line, and stopping, with a small, durable controller outside that holds the state and decides when the next turn should run. The agent gets to be powerful and forgetful; the controller gets to be simple and reliable. The waiting, which is where loops go to die, belongs to neither of them. It belongs to the world, which wakes the agent only when there's something new to do.
+
+## Resources
+
+- [Claude Agent SDK overview](https://docs.claude.com/en/api/agent-sdk/overview)
+- [Building agents with the Claude Agent SDK](https://www.anthropic.com/engineering/building-agents-with-the-claude-agent-sdk)
+- [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)

--- a/images/autonomous-agents-that-sleep/architecture.svg
+++ b/images/autonomous-agents-that-sleep/architecture.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 470" width="100%" style="max-width:900px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background:#fafafa;">
+  <defs>
+    <marker id="ar-slate" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 z" fill="#41525E"/>
+    </marker>
+    <marker id="ar-indigo" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 z" fill="#5B6BB5"/>
+    </marker>
+  </defs>
+
+  <text x="450" y="34" text-anchor="middle" font-size="19" font-weight="700" fill="#2b3640">Turn the loop inside-out: the durable part lives outside the agent</text>
+
+  <!-- ===== the world (events) ===== -->
+  <text x="96" y="96" text-anchor="middle" font-size="12" font-weight="600" fill="#76828c">the world</text>
+  <g font-size="10.5" text-anchor="middle">
+    <g>
+      <rect x="40" y="110" width="112" height="28" rx="14" fill="#EEEEFB" stroke="#5B6BB5" stroke-width="1.2"/>
+      <text x="96" y="128" fill="#4a59a3">CI result</text>
+      <rect x="38" y="108" width="116" height="32" rx="16" fill="none" stroke="#5B6BB5" stroke-width="2.4">
+        <animate attributeName="opacity" dur="6s" repeatCount="indefinite" keyTimes="0;0.02;0.12;0.16;1" values="1;1;1;0;0"/>
+      </rect>
+    </g>
+    <rect x="40" y="148" width="112" height="28" rx="14" fill="#EEEEFB" stroke="#5B6BB5" stroke-width="1.2"/>
+    <text x="96" y="166" fill="#4a59a3">review comment</text>
+    <rect x="40" y="186" width="112" height="28" rx="14" fill="#EEEEFB" stroke="#5B6BB5" stroke-width="1.2"/>
+    <text x="96" y="204" fill="#4a59a3">new ticket</text>
+    <rect x="40" y="224" width="112" height="28" rx="14" fill="#EEEEFB" stroke="#5B6BB5" stroke-width="1.2"/>
+    <text x="96" y="242" fill="#4a59a3">human steps in</text>
+  </g>
+  <path d="M152,181 H190" fill="none" stroke="#5B6BB5" stroke-width="2.2" marker-end="url(#ar-indigo)"/>
+  <text x="172" y="173" text-anchor="middle" font-size="10.5" fill="#5B6BB5">events</text>
+
+  <!-- ===== controller ===== -->
+  <rect x="195" y="92" width="315" height="300" rx="14" fill="#ECF0F2" stroke="#41525E" stroke-width="2"/>
+  <text x="214" y="120" font-size="15" font-weight="700" fill="#41525E">CONTROLLER</text>
+  <text x="214" y="140" font-size="11" fill="#76828c">always on</text>
+
+  <!-- datastore cylinder -->
+  <g fill="#ffffff" stroke="#41525E" stroke-width="1.6">
+    <path d="M290,165 v62 a62,13 0 0 0 124,0 v-62" />
+    <ellipse cx="352" cy="165" rx="62" ry="13"/>
+  </g>
+  <text x="352" y="200" text-anchor="middle" font-size="12.5" font-weight="600" fill="#41525E">durable state</text>
+  <text x="352" y="252" text-anchor="middle" font-size="10.5" fill="#76828c">session id · open PRs</text>
+  <text x="352" y="268" text-anchor="middle" font-size="10.5" fill="#76828c">what's still pending</text>
+  <!-- state-updated glow -->
+  <g fill="none" stroke="#D6A22E" stroke-width="3">
+    <path d="M290,165 v62 a62,13 0 0 0 124,0 v-62"/>
+    <ellipse cx="352" cy="165" rx="62" ry="13"/>
+    <animate attributeName="opacity" dur="6s" repeatCount="indefinite" keyTimes="0;0.78;0.83;0.92;0.96;1" values="0;0;0.9;0.9;0;0"/>
+  </g>
+
+  <text x="352" y="358" text-anchor="middle" font-size="12" font-style="italic" fill="#76828c">no event? it just waits.
+    <animate attributeName="opacity" values="0.5;1;0.5" dur="3s" repeatCount="indefinite"/>
+  </text>
+
+  <!-- ===== agent turn (ephemeral: spun up, then gone) ===== -->
+  <g>
+    <animate attributeName="opacity" dur="6s" repeatCount="indefinite" keyTimes="0;0.16;0.30;0.82;0.92;1" values="0.35;0.35;1;1;0.35;0.35"/>
+    <rect x="600" y="150" width="255" height="190" rx="14" fill="#EAF3FC" stroke="#3D7DBF" stroke-width="2" stroke-dasharray="7 5"/>
+    <text x="618" y="180" font-size="14" font-weight="700" fill="#3D7DBF">AGENT TURN</text>
+    <text x="618" y="199" font-size="10.5" fill="#76828c">stateless: spun up, then gone</text>
+    <!-- sliding highlight over the steps -->
+    <rect x="616" y="218" width="224" height="22" rx="5" fill="#FFE08A">
+      <animate attributeName="opacity" dur="6s" repeatCount="indefinite" keyTimes="0;0.36;0.4;0.57;0.6;1" values="0;0;0.55;0.55;0;0"/>
+      <animateTransform attributeName="transform" type="translate" dur="6s" repeatCount="indefinite" keyTimes="0;0.36;0.45;0.55;1" values="0 0;0 0;0 26;0 52;0 52"/>
+    </rect>
+    <g font-size="12.5" fill="#2b3640">
+      <text x="624" y="232">› resume the session</text>
+      <text x="624" y="258">› do the work</text>
+      <text x="624" y="284">› report status, exit</text>
+    </g>
+  </g>
+
+  <!-- arrows controller <-> turn -->
+  <path d="M510,205 H590" fill="none" stroke="#41525E" stroke-width="2.2" marker-end="url(#ar-slate)"/>
+  <text x="552" y="197" text-anchor="middle" font-size="11" fill="#41525E">spawn a turn</text>
+
+  <path d="M600,300 H520" fill="none" stroke="#41525E" stroke-width="2.2" marker-end="url(#ar-slate)"/>
+  <text x="556" y="292" text-anchor="middle" font-size="10.5" font-family="'SFMono-Regular',Menlo,Consolas,monospace" fill="#41525E">AGENT_STATUS</text>
+  <text x="556" y="318" text-anchor="middle" font-size="10.5" font-style="italic" fill="#76828c">then it exits</text>
+
+  <!-- ===== traveling dots: event -> controller -> turn -> back ===== -->
+  <circle r="5" fill="#5B6BB5">
+    <animateMotion dur="6s" repeatCount="indefinite" path="M152,181 L188,181" keyPoints="0;1;1" keyTimes="0;0.15;1" calcMode="linear"/>
+    <animate attributeName="opacity" dur="6s" repeatCount="indefinite" keyTimes="0;0.14;0.16;1" values="1;1;0;0"/>
+  </circle>
+  <circle r="5" fill="#41525E">
+    <animateMotion dur="6s" repeatCount="indefinite" path="M510,205 L588,205" keyPoints="0;0;1;1" keyTimes="0;0.18;0.32;1" calcMode="linear"/>
+    <animate attributeName="opacity" dur="6s" repeatCount="indefinite" keyTimes="0;0.18;0.19;0.32;0.34;1" values="0;0;1;1;0;0"/>
+  </circle>
+  <circle r="5" fill="#41525E">
+    <animateMotion dur="6s" repeatCount="indefinite" path="M600,300 L522,300" keyPoints="0;0;1;1" keyTimes="0;0.63;0.79;1" calcMode="linear"/>
+    <animate attributeName="opacity" dur="6s" repeatCount="indefinite" keyTimes="0;0.63;0.64;0.79;0.81;1" values="0;0;1;1;0;0"/>
+  </circle>
+
+  <text x="450" y="442" text-anchor="middle" font-size="13.5" fill="#41525E">Events go to the controller, not the agent. It holds the state and rents the agent one turn at a time.</text>
+</svg>

--- a/images/autonomous-agents-that-sleep/lifecycle.svg
+++ b/images/autonomous-agents-that-sleep/lifecycle.svg
@@ -1,0 +1,122 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 470" width="100%" style="max-width:900px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background:#fafafa;">
+  <defs>
+    <marker id="lf-slate" markerUnits="userSpaceOnUse" markerWidth="11" markerHeight="11" refX="9" refY="5.5" orient="auto">
+      <path d="M0,0 L11,5.5 L0,11 z" fill="#5A6B78"/>
+    </marker>
+    <marker id="lf-indigo" markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="12" refX="9" refY="6" orient="auto">
+      <path d="M0,0 L12,6 L0,12 z" fill="#5B6BB5"/>
+    </marker>
+  </defs>
+
+  <!-- title -->
+  <text x="450" y="36" text-anchor="middle" font-size="19" font-weight="700" fill="#2b3640">One turn, then stop. The world wakes it back up</text>
+
+  <!-- ===== connecting arrows (behind nodes) ===== -->
+  <g stroke="#5A6B78" stroke-width="2" fill="none">
+    <line x1="218" y1="190" x2="262" y2="190" marker-end="url(#lf-slate)"/>
+    <line x1="426" y1="190" x2="470" y2="190" marker-end="url(#lf-slate)"/>
+    <line x1="634" y1="190" x2="678" y2="190" marker-end="url(#lf-slate)"/>
+  </g>
+  <text x="240" y="181" text-anchor="middle" font-size="11" fill="#76828c">emit</text>
+  <text x="448" y="181" text-anchor="middle" font-size="11" fill="#76828c">then</text>
+  <text x="656" y="181" text-anchor="middle" font-size="11" fill="#76828c">idle</text>
+
+  <!-- return arrow: WAKE -> TURN (stops just below the TURN box) -->
+  <path d="M762,256 L762,338 Q762,352 748,352 L152,352 Q138,352 138,338 L138,262"
+        fill="none" stroke="#5B6BB5" stroke-width="2.5" marker-end="url(#lf-indigo)"/>
+  <text x="450" y="346" text-anchor="middle" font-size="12.5" font-weight="600" fill="#5B6BB5">a change wakes the next turn</text>
+
+  <!-- ===== node 1: TURN (agent awake) ===== -->
+  <g>
+    <rect x="62" y="124" width="152" height="132" rx="12" fill="#EAF3FC" stroke="#3D7DBF" stroke-width="1.6"/>
+    <text x="138" y="116" text-anchor="middle" font-size="12" font-weight="700" letter-spacing="1" fill="#3D7DBF">TURN</text>
+    <circle cx="138" cy="158" r="17" fill="#fff" stroke="#3D7DBF" stroke-width="1.6"/>
+    <circle cx="132" cy="156" r="2.4" fill="#3D7DBF"/>
+    <circle cx="144" cy="156" r="2.4" fill="#3D7DBF"/>
+    <path d="M131,164 Q138,169 145,164" fill="none" stroke="#3D7DBF" stroke-width="1.6"/>
+    <text x="138" y="196" text-anchor="middle" font-size="12.5" fill="#2b3640">scope · edit</text>
+    <text x="138" y="214" text-anchor="middle" font-size="12.5" fill="#2b3640">verify · push</text>
+    <text x="138" y="238" text-anchor="middle" font-size="11" fill="#76828c">the agent, working</text>
+  </g>
+
+  <!-- ===== node 2: REPORT (status line) ===== -->
+  <g>
+    <rect x="270" y="124" width="152" height="132" rx="12" fill="#FFF6E0" stroke="#D6A22E" stroke-width="1.6"/>
+    <text x="346" y="116" text-anchor="middle" font-size="12" font-weight="700" letter-spacing="1" fill="#B9871f">REPORT</text>
+    <rect x="288" y="158" width="116" height="46" rx="7" fill="#fff" stroke="#D6A22E" stroke-width="1.3"/>
+    <text x="346" y="178" text-anchor="middle" font-size="10.5" font-family="'SFMono-Regular',Menlo,Consolas,monospace" fill="#8a6a14">AGENT_STATUS:</text>
+    <text x="346" y="194" text-anchor="middle" font-size="10.5" font-family="'SFMono-Regular',Menlo,Consolas,monospace" fill="#8a6a14">{"prs":[…]}</text>
+    <text x="346" y="232" text-anchor="middle" font-size="11" fill="#76828c">one machine-</text>
+    <text x="346" y="246" text-anchor="middle" font-size="11" fill="#76828c">readable line</text>
+  </g>
+
+  <!-- ===== node 3: STOP (asleep) ===== -->
+  <g>
+    <rect x="478" y="124" width="152" height="132" rx="12" fill="#F1F3F5" stroke="#AEB7Bf" stroke-width="1.6"/>
+    <text x="554" y="116" text-anchor="middle" font-size="12" font-weight="700" letter-spacing="1" fill="#8a949c">STOP</text>
+    <circle cx="554" cy="158" r="17" fill="#fff" stroke="#AEB7Bf" stroke-width="1.6"/>
+    <path d="M547,157 q3,-3 6,0" fill="none" stroke="#8a949c" stroke-width="1.6"/>
+    <path d="M555,157 q3,-3 6,0" fill="none" stroke="#8a949c" stroke-width="1.6"/>
+    <path d="M549,165 q5,3 10,0" fill="none" stroke="#8a949c" stroke-width="1.6"/>
+    <g fill="#8a949c" font-style="italic" font-weight="700">
+      <text x="575" y="151" font-size="11">z<animate attributeName="opacity" values="0.25;1;0.25" dur="2.6s" begin="0s" repeatCount="indefinite"/></text>
+      <text x="582" y="143" font-size="13">z<animate attributeName="opacity" values="0.25;1;0.25" dur="2.6s" begin="0.4s" repeatCount="indefinite"/></text>
+      <text x="590" y="134" font-size="15">z<animate attributeName="opacity" values="0.25;1;0.25" dur="2.6s" begin="0.8s" repeatCount="indefinite"/></text>
+    </g>
+    <text x="554" y="202" text-anchor="middle" font-size="12.5" fill="#2b3640">the turn ends</text>
+    <text x="554" y="234" text-anchor="middle" font-size="11" fill="#76828c">no waiting,</text>
+    <text x="554" y="248" text-anchor="middle" font-size="11" fill="#76828c">no polling</text>
+  </g>
+
+  <!-- ===== node 4: WAKE (event) ===== -->
+  <g>
+    <rect x="686" y="124" width="152" height="132" rx="12" fill="#EEEEFB" stroke="#5B6BB5" stroke-width="1.6"/>
+    <text x="762" y="116" text-anchor="middle" font-size="12" font-weight="700" letter-spacing="1" fill="#4a59a3">WAKE</text>
+    <!-- bell icon -->
+    <g stroke="#5B6BB5" stroke-width="1.6" fill="#fff" stroke-linejoin="round">
+      <circle cx="762" cy="141" r="1.6" fill="#5B6BB5" stroke="none"/>
+      <path d="M754,156 C754,145 757,142 762,142 C767,142 770,145 770,156 Z"/>
+      <line x1="751" y1="156" x2="773" y2="156"/>
+    </g>
+    <circle cx="762" cy="159" r="2" fill="#5B6BB5"/>
+    <g font-size="10.5" font-family="'SFMono-Regular',Menlo,Consolas,monospace">
+      <rect x="703" y="170" width="118" height="19" rx="4" fill="#fff" stroke="#5B6BB5" stroke-width="1"/>
+      <text x="762" y="183" text-anchor="middle" fill="#4a59a3">CI failed</text>
+      <rect x="703" y="194" width="118" height="19" rx="4" fill="#fff" stroke="#5B6BB5" stroke-width="1"/>
+      <text x="762" y="207" text-anchor="middle" fill="#4a59a3">review comment</text>
+      <rect x="703" y="218" width="118" height="19" rx="4" fill="#fff" stroke="#5B6BB5" stroke-width="1"/>
+      <text x="762" y="231" text-anchor="middle" fill="#4a59a3">human steps in</text>
+    </g>
+  </g>
+
+  <!-- ===== traveling highlight rings ===== -->
+  <g fill="none" stroke-width="3.5">
+    <rect x="57" y="119" width="162" height="142" rx="15" stroke="#3D7DBF">
+      <animate attributeName="opacity" dur="8s" repeatCount="indefinite"
+        keyTimes="0; 0.23; 0.25; 0.96; 1" values="1; 1; 0; 0; 1"/>
+    </rect>
+    <rect x="265" y="119" width="162" height="142" rx="15" stroke="#D6A22E">
+      <animate attributeName="opacity" dur="8s" repeatCount="indefinite"
+        keyTimes="0; 0.25; 0.27; 0.375; 0.40; 1" values="0; 0; 1; 1; 0; 0"/>
+    </rect>
+    <rect x="473" y="119" width="162" height="142" rx="15" stroke="#8a949c">
+      <animate attributeName="opacity" dur="8s" repeatCount="indefinite"
+        keyTimes="0; 0.375; 0.40; 0.6875; 0.71; 1" values="0; 0; 1; 1; 0; 0"/>
+    </rect>
+    <rect x="681" y="119" width="162" height="142" rx="15" stroke="#5B6BB5">
+      <animate attributeName="opacity" dur="8s" repeatCount="indefinite"
+        keyTimes="0; 0.6875; 0.71; 0.875; 0.90; 1" values="0; 0; 1; 1; 0; 0"/>
+    </rect>
+  </g>
+
+  <!-- "time passes" marker that shows during the STOP window -->
+  <text x="554" y="288" text-anchor="middle" font-size="10.5" fill="#AEB7Bf">
+    time passes…
+    <animate attributeName="opacity" dur="8s" repeatCount="indefinite"
+      keyTimes="0; 0.40; 0.45; 0.66; 0.71; 1" values="0; 0; 1; 1; 0; 0"/>
+  </text>
+
+  <!-- ===== bottom caption ===== -->
+  <text x="450" y="404" text-anchor="middle" font-size="13.5" fill="#41525E">The agent does one turn and stops. A controller <tspan font-style="italic">outside</tspan> it holds the state,</text>
+  <text x="450" y="424" text-anchor="middle" font-size="13.5" fill="#41525E">waits, and starts the next turn only when something actually changes.</text>
+</svg>

--- a/images/autonomous-agents-that-sleep/naive-loop.svg
+++ b/images/autonomous-agents-that-sleep/naive-loop.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 430" width="100%" style="max-width:900px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background:#fafafa;">
+  <defs>
+    <marker id="nl-slate" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 z" fill="#5A6B78"/>
+    </marker>
+    <marker id="nl-red" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 z" fill="#E2574A"/>
+    </marker>
+  </defs>
+
+  <text x="450" y="34" text-anchor="middle" font-size="19" font-weight="700" fill="#2b3640">The obvious build: a loop that runs until the work is done</text>
+
+  <!-- ===== the loop ===== -->
+  <rect x="60" y="66" width="372" height="300" rx="14" fill="#ffffff" stroke="#AEB7Bf" stroke-width="1.6" stroke-dasharray="6 5"/>
+  <text x="80" y="92" font-size="12" font-family="'SFMono-Regular',Menlo,Consolas,monospace" fill="#76828c">while not done:</text>
+
+  <rect x="92" y="104" width="210" height="46" rx="9" fill="#F1F3F5" stroke="#AEB7Bf" stroke-width="1.4"/>
+  <text x="197" y="132" text-anchor="middle" font-size="13" fill="#2b3640">call the model</text>
+
+  <line x1="197" y1="150" x2="197" y2="170" stroke="#5A6B78" stroke-width="2" marker-end="url(#nl-slate)" fill="none"/>
+  <rect x="92" y="172" width="210" height="46" rx="9" fill="#F1F3F5" stroke="#AEB7Bf" stroke-width="1.4"/>
+  <text x="197" y="200" text-anchor="middle" font-size="13" fill="#2b3640">take an action: edit, push</text>
+
+  <line x1="197" y1="218" x2="197" y2="238" stroke="#5A6B78" stroke-width="2" marker-end="url(#nl-slate)" fill="none"/>
+  <rect x="92" y="240" width="210" height="46" rx="9" fill="#F1F3F5" stroke="#AEB7Bf" stroke-width="1.4"/>
+  <text x="197" y="268" text-anchor="middle" font-size="13" fill="#2b3640">CI green? review done?</text>
+
+  <!-- sequential highlight rings -->
+  <g fill="none" stroke="#5A6B78" stroke-width="3">
+    <rect x="87" y="99" width="220" height="56" rx="12">
+      <animate attributeName="opacity" dur="4.4s" repeatCount="indefinite" keyTimes="0;0.22;0.25;0.97;1" values="1;1;0;0;1"/>
+    </rect>
+    <rect x="87" y="167" width="220" height="56" rx="12">
+      <animate attributeName="opacity" dur="4.4s" repeatCount="indefinite" keyTimes="0;0.25;0.27;0.5;0.52;1" values="0;0;1;1;0;0"/>
+    </rect>
+    <rect x="87" y="235" width="220" height="56" rx="12">
+      <animate attributeName="opacity" dur="4.4s" repeatCount="indefinite" keyTimes="0;0.5;0.52;0.75;0.77;1" values="0;0;1;1;0;0"/>
+    </rect>
+  </g>
+
+  <!-- return arrow: flows out of box C, pauses at the clock, then back to the top -->
+  <path d="M302,263 H342" fill="none" stroke="#E2574A" stroke-width="2.4" stroke-dasharray="9 7">
+    <animate attributeName="stroke-dashoffset" from="64" to="0" dur="1.4s" repeatCount="indefinite"/>
+  </path>
+  <path d="M374,263 H400 V127 H304" fill="none" stroke="#E2574A" stroke-width="2.4" stroke-dasharray="9 7" marker-end="url(#nl-red)">
+    <animate attributeName="stroke-dashoffset" from="160" to="0" dur="1.4s" repeatCount="indefinite"/>
+  </path>
+
+  <!-- waiting clock sits on the path (drawn on top so the line never crosses it) -->
+  <g>
+    <circle cx="358" cy="263" r="13" fill="#FBEBE9" stroke="#E2574A" stroke-width="1.6"/>
+    <line x1="358" y1="263" x2="362" y2="266" stroke="#E2574A" stroke-width="1.6"/>
+    <line x1="358" y1="263" x2="358" y2="254" stroke="#E2574A" stroke-width="1.8">
+      <animateTransform attributeName="transform" type="rotate" from="0 358 263" to="360 358 263" dur="2.4s" repeatCount="indefinite"/>
+    </line>
+  </g>
+
+  <text x="362" y="120" text-anchor="middle" font-size="11.5" font-weight="600" fill="#E2574A">still pending → retry</text>
+
+  <!-- budget creeping up while it waits -->
+  <text x="197" y="307" text-anchor="middle" font-size="10.5" fill="#76828c">budget spent while waiting</text>
+  <rect x="110" y="314" width="174" height="9" rx="4" fill="#eceff1" stroke="#d7dde1" stroke-width="1"/>
+  <rect x="110" y="314" width="0" height="9" rx="4" fill="#E2574A">
+    <animate attributeName="width" values="0;174;174" keyTimes="0;0.85;1" dur="4.4s" repeatCount="indefinite"/>
+  </rect>
+
+  <!-- ===== three ways it breaks ===== -->
+  <text x="470" y="86" font-size="14" font-weight="700" fill="#E2574A">Three ways it breaks</text>
+
+  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+    <rect x="470" y="100" width="388" height="74" rx="10" fill="#ffffff" stroke="#cfd6db" stroke-width="1.3"/>
+    <rect x="470" y="100" width="6" height="74" rx="3" fill="#E2574A"/>
+    <text x="492" y="128" font-size="14.5" font-weight="700" fill="#2b3640">Burns budget</text>
+    <text x="492" y="150" font-size="12" fill="#76828c">It polls a 12-minute build, paying for every spin.</text>
+
+    <rect x="470" y="186" width="388" height="74" rx="10" fill="#ffffff" stroke="#cfd6db" stroke-width="1.3"/>
+    <rect x="470" y="186" width="6" height="74" rx="3" fill="#E2574A"/>
+    <text x="492" y="214" font-size="14.5" font-weight="700" fill="#2b3640">Can't be steered</text>
+    <text x="492" y="236" font-size="12" fill="#76828c">A new instruction waits until the loop checks for it.</text>
+
+    <rect x="470" y="272" width="388" height="74" rx="10" fill="#ffffff" stroke="#cfd6db" stroke-width="1.3"/>
+    <rect x="470" y="272" width="6" height="74" rx="3" fill="#E2574A"/>
+    <text x="492" y="300" font-size="14.5" font-weight="700" fill="#2b3640">A crash is amnesia</text>
+    <text x="492" y="322" font-size="12" fill="#76828c">Progress lives in memory; restart and it's lost.</text>
+  </g>
+
+  <text x="450" y="406" text-anchor="middle" font-size="13.5" fill="#41525E">It demos beautifully, until the agent has to wait for something.</text>
+</svg>

--- a/images/autonomous-agents-that-sleep/status-contract.svg
+++ b/images/autonomous-agents-that-sleep/status-contract.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 440" width="100%" style="max-width:900px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background:#fafafa;">
+  <defs>
+    <marker id="sc-amber" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+      <path d="M0,0 L9,4.5 L0,9 z" fill="#D6A22E"/>
+    </marker>
+  </defs>
+
+  <text x="450" y="34" text-anchor="middle" font-size="19" font-weight="700" fill="#2b3640">Two readers, one turn: prose for people, one line for code</text>
+
+  <!-- ===== left: the turn's reply ===== -->
+  <rect x="45" y="70" width="430" height="300" rx="12" fill="#ffffff" stroke="#cfd6db" stroke-width="1.4"/>
+  <text x="64" y="98" font-size="11" font-weight="600" fill="#76828c">THE TURN'S REPLY</text>
+
+  <g font-size="12.5" fill="#41525E">
+    <text x="66" y="126">Scoped it to the backend repo and added</text>
+    <text x="66" y="146">the missing null-check. Tests pass locally.</text>
+    <text x="66" y="166">Opened a draft PR. Link above.</text>
+  </g>
+
+  <rect x="62" y="188" width="396" height="150" rx="8" fill="#FFF6E0" stroke="#D6A22E" stroke-width="1.4"/>
+  <g font-size="12" font-family="'SFMono-Regular',Menlo,Consolas,monospace" fill="#8a6a14">
+    <text x="78" y="214">AGENT_STATUS: {</text>
+    <text x="78" y="236">  "prs": [{ "repo": "backend",</text>
+    <text x="78" y="258">            "url": ".../pull/42" }],</text>
+    <text x="78" y="280">  "note": "opened a draft PR"</text>
+    <text x="78" y="302">}</text>
+  </g>
+  <!-- "parsed" glow on the status line -->
+  <rect x="58" y="184" width="404" height="158" rx="10" fill="none" stroke="#D6A22E" stroke-width="3">
+    <animate attributeName="opacity" dur="5.2s" repeatCount="indefinite" keyTimes="0;0.04;0.18;0.24;1" values="0;0.95;0.95;0;0"/>
+  </rect>
+  <text x="260" y="356" text-anchor="middle" font-size="11.5" font-style="italic" fill="#76828c">the prose is for a human; the last line is for code</text>
+
+  <!-- arrow: read last line -->
+  <path d="M478,212 H548" fill="none" stroke="#D6A22E" stroke-width="2.2" marker-end="url(#sc-amber)"/>
+  <text x="513" y="204" text-anchor="middle" font-size="10.5" fill="#b9871f">read last line</text>
+  <circle r="5" fill="#D6A22E">
+    <animateMotion dur="5.2s" repeatCount="indefinite" path="M478,212 L546,212" keyPoints="0;0;1;1" keyTimes="0;0.2;0.34;1" calcMode="linear"/>
+    <animate attributeName="opacity" dur="5.2s" repeatCount="indefinite" keyTimes="0;0.2;0.21;0.34;0.36;1" values="0;0;1;1;0;0"/>
+  </circle>
+
+  <!-- ===== right: what the orchestrator does ===== -->
+  <text x="560" y="98" font-size="12" font-weight="700" fill="#41525E">WHAT THE CONTROLLER DOES</text>
+
+  <!-- row: prs -->
+  <g>
+    <animate attributeName="opacity" dur="5.2s" repeatCount="indefinite" keyTimes="0;0.36;0.44;1" values="0.5;0.5;1;1"/>
+    <rect x="560" y="138" width="64" height="26" rx="6" fill="#FFF6E0" stroke="#D6A22E" stroke-width="1.2"/>
+    <text x="592" y="156" text-anchor="middle" font-size="11.5" font-family="'SFMono-Regular',Menlo,Consolas,monospace" fill="#8a6a14">prs</text>
+    <text x="640" y="156" font-size="12.5" fill="#2b3640">→ watch PR #42 for CI + reviews</text>
+  </g>
+  <!-- row: note -->
+  <g>
+    <animate attributeName="opacity" dur="5.2s" repeatCount="indefinite" keyTimes="0;0.5;0.58;1" values="0.5;0.5;1;1"/>
+    <rect x="560" y="200" width="64" height="26" rx="6" fill="#FFF6E0" stroke="#D6A22E" stroke-width="1.2"/>
+    <text x="592" y="218" text-anchor="middle" font-size="11.5" font-family="'SFMono-Regular',Menlo,Consolas,monospace" fill="#8a6a14">note</text>
+    <text x="640" y="218" font-size="12.5" fill="#2b3640">→ surface it to a human</text>
+  </g>
+  <!-- row: attention -->
+  <g>
+    <animate attributeName="opacity" dur="5.2s" repeatCount="indefinite" keyTimes="0;0.64;0.72;1" values="0.5;0.5;1;1"/>
+    <rect x="560" y="262" width="92" height="26" rx="6" fill="#FFF6E0" stroke="#D6A22E" stroke-width="1.2"/>
+    <text x="606" y="280" text-anchor="middle" font-size="11.5" font-family="'SFMono-Regular',Menlo,Consolas,monospace" fill="#8a6a14">attention</text>
+    <text x="668" y="274" font-size="12.5" fill="#2b3640">→ only if blocked:</text>
+    <text x="668" y="292" font-size="12.5" fill="#2b3640">ping a human, pause</text>
+  </g>
+
+  <text x="450" y="414" text-anchor="middle" font-size="13.5" fill="#41525E">The agent reports state in a fixed shape, so code drives the loop without ever reading the prose.</text>
+</svg>


### PR DESCRIPTION
## Overview

- [x] new post "Autonomous agents that sleep": building autonomous agents with the Claude Agent SDK, where a stateful controller drives short, stateless agent turns
- [x] four hand-crafted animated SVGs (SMIL): lifecycle, naive loop, controller architecture, status contract
- [x] follows the repo's writing conventions (concept before code, hero visual, "we" voice)

## Preview

`bundle exec jekyll serve` then open http://localhost:4000/autonomous-agents-that-sleep/